### PR TITLE
Fixed indentation in .pre-commit-config.yaml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,52 +6,52 @@ repos:
   rev: v0.1.14
   hooks:
     # Run the linter.
-    - id: ruff
-      args: [ --fix ]
+  - id: ruff
+    args: [ --fix ]
     # Run the formatter.
-    - id: ruff-format
+  - id: ruff-format
 
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v4.5.0
   hooks:
-  -   id: trailing-whitespace
-  -   id: end-of-file-fixer
-      # exlude j2
-      exclude: ^.*\.j2$
-  -   id: check-yaml
-  -   id: check-added-large-files
-      args: ['--maxkb=5000']
-  -   id: check-ast
-  -   id: check-docstring-first
-  -   id: detect-private-key
+  - id: trailing-whitespace
+  - id: end-of-file-fixer
+    # exlude j2
+    exclude: ^.*\.j2$
+  - id: check-yaml
+  - id: check-added-large-files
+    args: ['--maxkb=5000']
+  - id: check-ast
+  - id: check-docstring-first
+  - id: detect-private-key
 
 - repo: https://github.com/adamchainz/blacken-docs
   rev: 1.13.0  # replace with latest tag on GitHub
   hooks:
-  -   id: blacken-docs
-      additional_dependencies:
-      - black==22.12.0
+  - id: blacken-docs
+    additional_dependencies:
+    - black==22.12.0
 
 # shows old code and how to update it
 - repo: https://github.com/asottile/pyupgrade
   rev: v2.7.2
   hooks:
-  -   id: pyupgrade
-      args: [--py38-plus]
+  - id: pyupgrade
+    args: [--py38-plus]
 
 # for poetry projects
 - repo: https://github.com/python-poetry/poetry
   rev: 1.3.2  # add version here
   hooks:
-  -   id: poetry-check
-  -   id: poetry-lock
-      args: ["--no-update"]
-      language_version: python3.11
-  -   id: poetry-export
-      args: ["-f", "requirements.txt", "-o", "requirements.txt"]
+  - id: poetry-check
+  - id: poetry-lock
+    args: ["--no-update"]
+    language_version: python3.11
+  - id: poetry-export
+    args: ["-f", "requirements.txt", "-o", "requirements.txt"]
 
 - repo: https://github.com/Lucas-C/pre-commit-hooks-safety
   rev: v1.3.1
   hooks:
-  -   id: python-safety-dependencies-check
-      files: pyproject.toml
+  - id: python-safety-dependencies-check
+    files: pyproject.toml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,47 +11,47 @@ repos:
     # Run the formatter.
     - id: ruff-format
 
--   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
-    hooks:
-    -   id: trailing-whitespace
-    -   id: end-of-file-fixer
-        # exlude j2
-        exclude: ^.*\.j2$
-    -   id: check-yaml
-    -   id: check-added-large-files
-        args: ['--maxkb=5000']
-    -   id: check-ast
-    -   id: check-docstring-first
-    -   id: detect-private-key
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v4.5.0
+  hooks:
+  -   id: trailing-whitespace
+  -   id: end-of-file-fixer
+      # exlude j2
+      exclude: ^.*\.j2$
+  -   id: check-yaml
+  -   id: check-added-large-files
+      args: ['--maxkb=5000']
+  -   id: check-ast
+  -   id: check-docstring-first
+  -   id: detect-private-key
 
--   repo: https://github.com/adamchainz/blacken-docs
-    rev: 1.13.0  # replace with latest tag on GitHub
-    hooks:
-    -   id: blacken-docs
-        additional_dependencies:
-        - black==22.12.0
+- repo: https://github.com/adamchainz/blacken-docs
+  rev: 1.13.0  # replace with latest tag on GitHub
+  hooks:
+  -   id: blacken-docs
+      additional_dependencies:
+      - black==22.12.0
 
 # shows old code and how to update it
--   repo: https://github.com/asottile/pyupgrade
-    rev: v2.7.2
-    hooks:
-    -   id: pyupgrade
-        args: [--py38-plus]
+- repo: https://github.com/asottile/pyupgrade
+  rev: v2.7.2
+  hooks:
+  -   id: pyupgrade
+      args: [--py38-plus]
 
 # for poetry projects
--   repo: https://github.com/python-poetry/poetry
-    rev: 1.3.2  # add version here
-    hooks:
-    -   id: poetry-check
-    -   id: poetry-lock
-        args: ["--no-update"]
-        language_version: python3.11
-    -   id: poetry-export
-        args: ["-f", "requirements.txt", "-o", "requirements.txt"]
+- repo: https://github.com/python-poetry/poetry
+  rev: 1.3.2  # add version here
+  hooks:
+  -   id: poetry-check
+  -   id: poetry-lock
+      args: ["--no-update"]
+      language_version: python3.11
+  -   id: poetry-export
+      args: ["-f", "requirements.txt", "-o", "requirements.txt"]
 
--   repo: https://github.com/Lucas-C/pre-commit-hooks-safety
-    rev: v1.3.1
-    hooks:
-    -   id: python-safety-dependencies-check
-        files: pyproject.toml
+- repo: https://github.com/Lucas-C/pre-commit-hooks-safety
+  rev: v1.3.1
+  hooks:
+  -   id: python-safety-dependencies-check
+      files: pyproject.toml


### PR DESCRIPTION
Indentation error leads to an incorrect config map when running `pre-commit run --all-files`